### PR TITLE
Suggested changes

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -12,10 +12,21 @@ Plug 'leafgarland/typescript-vim'
 call plug#end()
 
 "format:
-set tabstop=2
-set softtabstop=2
-set shiftwidth=2
+set tabstop=3
+set softtabstop=3
+set shiftwidth=3
 set expandtab "spaces > tabs
+set incsearch           " search as characters are entered
+set hlsearch            " highlight matches
+set showmatch           " highlight matching [{()}]
+set foldenable          " enable folding
+
+" move vertically by visual line
+nnoremap j gj
+nnoremap k gk
+
+" jk is escape
+inoremap jk <esc>
 
 "indent
 filetype plugin indent on
@@ -38,7 +49,6 @@ endif
 
 "search:
 set incsearch "realtime searching
-set ignorecase "ignore caps
 set smartcase "case sensitive if capital letter in query
 
 "lightline


### PR DESCRIPTION
I'm playing around with pull requests. Below are suggested changes/comments.

All the kewl kids use 3 spaces. 2 spaces is just TOO close.
Using "jk" to escape is one of my favorite vim shortcuts. The <ESC> key is too far away.
You can add "\c" anywhere in a vim search to make the whole search case insensitive.
The visual line change for scrolling makes it where you don't skip over wrapped lines.